### PR TITLE
Fix DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -182,6 +182,11 @@ The source code can be found on `github <http://www.github.com/comlounge/embeddi
 Changelog
 =========
 
+0.3.2 (2025-06-17)
+------------------
+
+- Support python 3.13 by using `html.escape` instead of deprecated `cgi.escape` [fschulze]
+
 0.3.1 (2017-08-28)
 ------------------
 

--- a/embeddify/embeddify.py
+++ b/embeddify/embeddify.py
@@ -11,7 +11,10 @@ try:
     from urllib import parse as urlparse
 except ImportError:
     import urlparse
-import cgi
+try:
+    from html import escape
+except ImportError:
+    from cgi import escape  # type: ignore
 import copy
 import json
 import re
@@ -157,7 +160,7 @@ class Flickr(OEmbedPlugin):
         new_data = {
             'url' : data['web_page'],
             'src' : data['url'],
-            'title' : cgi.escape(data['title']),
+            'title' : escape(data['title']),
             'width' : data['width'],
             'height' : data['height'],
         }


### PR DESCRIPTION
See issue #15